### PR TITLE
Makefile: replace spaces with tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 #CC=/volume/hab/Linux/Ubuntu-12.04/x86_64/gcc/jnpr/4.2.1/x86_64-unknown-linux-gnu.11/bin/gcc
 all:
-    ${CXX} -c \
-        sample_uninit.c 
+	${CXX} -c \
+	  sample_uninit.c 
 clean:
-    rm -rf *.o
+	rm -rf *.o


### PR DESCRIPTION
Fixes: `Makefile:5: *** missing separator. Stop.`